### PR TITLE
Scatterring

### DIFF
--- a/TempoNest.h
+++ b/TempoNest.h
@@ -58,13 +58,16 @@ typedef struct {
 	int *includeEQsys;
 	int numFitRedCoeff;
 	int numFitDMCoeff;
+        int numFitScatCoeff;
 	int totCoeff;
 	int numFitRedPL;
 	int numFitDMPL;
+        int numFitScatPL;
 	double *sampleFreq;
 	int numdims;
 	int incRED;
 	int incDM;
+        int incScat;
 	int incFloatDM;
 	int incFloatRed;
 	int yearlyDM;
@@ -98,6 +101,7 @@ typedef struct {
 	int numDMScatterShapeCoeff;
 	int RedPriorType;
 	int DMPriorType;
+        int ScatPriorType;
 	int EQUADPriorType;
 	int EFACPriorType;
 	int useOriginalErrors;
@@ -391,6 +395,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		int &incEQUAD,
 		int &incRED,
 		int &incDM,
+		 int &incScat, 
 		int &doTimeMargin,
 		int &doJumpMargin,
 		double &FitSig,
@@ -402,12 +407,17 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		double *AmpPrior,
 		double *DMAlphaPrior,
 		double *DMAmpPrior,
+		double *ScatAlphaPrior,
+                double *ScatAmpPrior, 
 		double &numRedCoeff,
 		double &numDMCoeff,
+		double &numScatCoeff, 
 		int &numRedPL,
 		int &numDMPL,
+		int &numScatPL,
 		double *RedCoeffPrior,
 		double *DMCoeffPrior,
+		double *ScatCoeffPrior,
 		int &FloatingDM,
 		double *DMFreqPrior,
 		int &yearlyDM,
@@ -425,6 +435,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		double *GWBAmpPrior,
 		int &RedPriorType,
 		int &DMPriorType,
+		int &ScatPriorType,
 		int &EQUADPriorType,
 		int &EFACPriorType,
 		int &useOriginalErrors,
@@ -513,7 +524,8 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		int &ScatterPBF);
 
 void setTNPriors(char *ConfigFileName, double **Dpriors, long double **TempoPriors, int TPsize, int DPsize);
-void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, int numDMfreqs, int numRedLogFreqs, int numDMLogFreqs, double RedLowFreq, double DMLowFreq, double RedMidFreq, double DMMidFreq);
+//void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, int numDMfreqs, int numRedLogFreqs, int numDMLogFreqs, double RedLowFreq, double DMLowFreq, double RedMidFreq, double DMMidFreq);
+void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, int numDMfreqs, int numScatfreqs, int numRedLogFreqs, int numDMLogFreqs, int numScatLogFreqs, double RedLowFreq, double DMLowFreq, double ScatLowFreq, double RedMidFreq, double DMMidFreq, double ScatMidFreq);
 void GetGroupsToFit(char *ConfigFileName, int incGroupNoise, int **FitForGroup, int incBandNoise, int **FitForBand);
 void setShapePriors(char *ConfigFileName, double **ShapePriors, double **BetaPrior, int numcoeff, int numcomps);
 void GetProfileFitInfo(char *ConfigFileName, int numProfComponents, int *numGPTAshapecoeff, int *numProfileFitCoeff, int *numEvoCoeff, int *numFitEvoCoeff, 	int *numGPTAstocshapecoeff, double *ProfCompSeps, double &TemplateChanWidth, int *TimeCorrShapeCoeff, int incExtraComp,  double **FitForExtraComp, int *FitCompWidths, int *FitCompPos);

--- a/TempoNestLikeFuncs.cpp
+++ b/TempoNestLikeFuncs.cpp
@@ -903,6 +903,7 @@ double  NewLRedMarginLogLike(double Cube[], int ndim, double phi[], int nDerived
 
 	int FitRedCoeff=2*(((MNStruct *)globalcontext)->numFitRedCoeff);
 	int FitDMCoeff=2*(((MNStruct *)globalcontext)->numFitDMCoeff);
+	int FitScatCoeff=2*(((MNStruct *)globalcontext)->numFitScatCoeff);
 	int FitBandCoeff=2*(((MNStruct *)globalcontext)->numFitBandNoiseCoeff);
 	int FitGroupNoiseCoeff = 2*((MNStruct *)globalcontext)->numFitGroupNoiseCoeff;
 
@@ -1352,7 +1353,63 @@ double  NewLRedMarginLogLike(double Cube[], int ndim, double phi[], int nDerived
 
         }
 
+/////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////Scattering variations ////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+       double *ScatVec=new double[((MNStruct *)globalcontext)->pulse->nobs];
 
+	if(((MNStruct *)globalcontext)->incScat > 0) {
+	  //printf("incScat = %d FitScatCoeff = %d numFitScatPL = %d freqSSB = %lf\n", ((MNStruct *)globalcontext)->incScat, FitScatCoeff, ((MNStruct *)globalcontext)->numFitScatPL, (double)((MNStruct *)globalcontext)->pulse->obsn[0].freqSSB);
+		for(int o=0;o<((MNStruct *)globalcontext)->pulse->nobs; o++){
+		  ScatVec[o]=1./(pow((double)((MNStruct *)globalcontext)->pulse->obsn[o].freqSSB/1400e6, 4)); // Referenced to 1.4 Ghz to be consistent with Enterprise; Invert to be consistent with Tempo2 - 20220810 GD/AP
+		}
+		printf("ScatVec = %lg\n", ScatVec[0]);
+		
+		for(int i=0;i<FitScatCoeff/2;i++){
+
+		        freqs[startpos+i]=((MNStruct *)globalcontext)->sampleFreq[startpos/2 - ((MNStruct *)globalcontext)->incFloatRed+i]/maxtspan;
+		        freqs[startpos+i+FitScatCoeff/2]=freqs[startpos+i];
+
+		        if(((MNStruct *)globalcontext)->storeFMatrices == 0){
+			        for(int k=0;k<((MNStruct *)globalcontext)->pulse->nobs;k++){
+                                        double time=(double)((MNStruct *)globalcontext)->pulse->obsn[k].bat;
+
+					TotalMatrix[k + (i+TimetoMargin+startpos)*((MNStruct *)globalcontext)->pulse->nobs]=cos(2*M_PI*freqs[startpos+i]*time)*ScatVec[k];
+                                        TotalMatrix[k + (i+FitScatCoeff/2+TimetoMargin+startpos)*((MNStruct *)globalcontext)->pulse->nobs] = sin(2*M_PI*freqs[startpos+i]*time)*ScatVec[k];
+
+				}
+                        }
+                }
+
+		for(int pl = 0; pl < ((MNStruct *)globalcontext)->numFitScatPL; pl++){
+                        double ScatAmp=Cube[pcount];
+                        pcount++;
+                        double ScatSlope=Cube[pcount];
+                        pcount++;
+			ScatAmp = -14.5;
+			ScatSlope = 3;
+
+			double Tspan = maxtspan;
+                        double f1yr = 1.0/3.16e7;
+
+
+			ScatAmp=pow(10.0, ScatAmp);
+                        if(((MNStruct *)globalcontext)->ScatPriorType ==1) { uniformpriorterm += log(ScatAmp); }
+                        for (int i=0; i<FitScatCoeff/2; i++){
+
+				double rho = (ScatAmp*ScatAmp)/12./M_PI/M_PI*pow(f1yr,(-3)) * pow(freqs[startpos+i]*365.25,(-ScatSlope))/(maxtspan*24*60*60);
+				//printf("freqs = %lg rho = %lg\n", freqs[startpos+i], rho);
+                                powercoeff[startpos+i]+=rho;
+                                powercoeff[startpos+i+FitScatCoeff/2]+=rho;
+                        }
+                }
+
+		for (int i=0; i<FitScatCoeff/2; i++){
+                        freqdet=freqdet+2*log(powercoeff[startpos+i]);
+                }
+                startpos+=FitScatCoeff;
+
+	}
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////  
@@ -1837,6 +1894,7 @@ double  NewLRedMarginLogLike(double Cube[], int ndim, double phi[], int nDerived
 
 
 	delete[] DMVec;
+	delete[] ScatVec;
 	delete[] WorkCoeff;
 	delete[] WorkCoeff2;
 	for(int i=0; i < ((MNStruct *)globalcontext)->EPolTerms; i++) delete[] EFAC[i];

--- a/TempoNestLikeFuncs.cpp
+++ b/TempoNestLikeFuncs.cpp
@@ -1359,11 +1359,9 @@ double  NewLRedMarginLogLike(double Cube[], int ndim, double phi[], int nDerived
        double *ScatVec=new double[((MNStruct *)globalcontext)->pulse->nobs];
 
 	if(((MNStruct *)globalcontext)->incScat > 0) {
-	  //printf("incScat = %d FitScatCoeff = %d numFitScatPL = %d freqSSB = %lf\n", ((MNStruct *)globalcontext)->incScat, FitScatCoeff, ((MNStruct *)globalcontext)->numFitScatPL, (double)((MNStruct *)globalcontext)->pulse->obsn[0].freqSSB);
-		for(int o=0;o<((MNStruct *)globalcontext)->pulse->nobs; o++){
-		  ScatVec[o]=1./(pow((double)((MNStruct *)globalcontext)->pulse->obsn[o].freqSSB/1400e6, 4)); // Referenced to 1.4 Ghz to be consistent with Enterprise; Invert to be consistent with Tempo2 - 20220810 GD/AP
-		}
-		printf("ScatVec = %lg\n", ScatVec[0]);
+	        if(((MNStruct *)globalcontext)->storeFMatrices == 0)
+	            for(int o=0;o<((MNStruct *)globalcontext)->pulse->nobs; o++)
+	                ScatVec[o]=1./(pow((double)((MNStruct *)globalcontext)->pulse->obsn[o].freqSSB/1400e6, 4)); // Referenced to 1.4 Ghz to be consistent with Enterprise; Invert to be consistent with Tempo2 - 20220810 GD/AP
 		
 		for(int i=0;i<FitScatCoeff/2;i++){
 
@@ -1386,19 +1384,15 @@ double  NewLRedMarginLogLike(double Cube[], int ndim, double phi[], int nDerived
                         pcount++;
                         double ScatSlope=Cube[pcount];
                         pcount++;
-			ScatAmp = -14.5;
-			ScatSlope = 3;
 
 			double Tspan = maxtspan;
                         double f1yr = 1.0/3.16e7;
-
 
 			ScatAmp=pow(10.0, ScatAmp);
                         if(((MNStruct *)globalcontext)->ScatPriorType ==1) { uniformpriorterm += log(ScatAmp); }
                         for (int i=0; i<FitScatCoeff/2; i++){
 
 				double rho = (ScatAmp*ScatAmp)/12./M_PI/M_PI*pow(f1yr,(-3)) * pow(freqs[startpos+i]*365.25,(-ScatSlope))/(maxtspan*24*60*60);
-				//printf("freqs = %lg rho = %lg\n", freqs[startpos+i], rho);
                                 powercoeff[startpos+i]+=rho;
                                 powercoeff[startpos+i+FitScatCoeff/2]+=rho;
                         }

--- a/TempoNestParams.cpp
+++ b/TempoNestParams.cpp
@@ -41,6 +41,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		int &incEQUAD,
 		int &incRED,
 		int &incDM,
+		int &incScat, 
 		int &doTimeMargin,
 		int &doJumpMargin,
 		double &FitSig,
@@ -52,12 +53,17 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		double *AmpPrior,
 		double *DMAlphaPrior,
 		double *DMAmpPrior,
+		double *ScatAlphaPrior,
+                double *ScatAmpPrior, 
 		double &numRedCoeff,
 		double &numDMCoeff,
+		double &numScatCoeff, 
 		int &numRedPL,
 		int &numDMPL,
+		int &numScatPL, 
 		double *RedCoeffPrior,
 		double *DMCoeffPrior,
+		double *ScatCoeffPrior, 
 		int &FloatingDM,
 		double *DMFreqPrior,
 		int &yearlyDM,
@@ -75,6 +81,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 		double *GWBAmpPrior,
 		int &RedPriorType,
 		int &DMPriorType,
+		int &ScatPriorType, 
 		int &EQUADPriorType,
 		int &EFACPriorType,
 		int &useOriginalErrors,
@@ -230,7 +237,8 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 
 	incRED=0; //include Red Noise model: 0 = no, 1 = power law model (vHL2013), 2 = model independent (L2013)
 	incDM=0; //include Red Noise model: 0 = no, 1 = power law model (vHL2013), 2 = model independent (L2013)
-
+	incScat=0; //include Scattering noise model: 0 = no, 1 = similar to power law model=3 for DM
+	
 	FitLowFreqCutoff = 0; //Include f_low as a free parameter
 
 	doTimeMargin=0 ; //0=No Analytical Marginalisation over Timing Model. 1=Marginalise over QSD. 2=Marginalise over all Model params excluding jumps.
@@ -298,6 +306,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 
 	RedPriorType = 0; // 0 = Log, 1 = Uniform
 	DMPriorType = 0;   // 0 = Log, 1 = Uniform
+	ScatPriorType = 0; // 0 = Log, 1 = Uniform
 	EQUADPriorType = 0;   // 0 = Log, 1 = Uniform
 	EFACPriorType = 0;   // 0 = Log, 1 = Uniform
 	usecosiprior = 0; // 0 = uniform in sini, 1 = uniform in cosi
@@ -324,9 +333,11 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 	
 	numRedPL=1;
 	numDMPL=1;
-
+	numScatPL=1;
+	
 	numRedCoeff=10;
 	numDMCoeff=10;
+	numScatCoeff=10;
 
 	varyRedCoeff=0;
 	varyDMCoeff=0;
@@ -343,6 +354,11 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 	DMAmpPrior[0]=-18;
 	DMAmpPrior[1]=-8;
 
+	ScatAlphaPrior[0]=1.1;
+        ScatAlphaPrior[1]=6.1;
+
+        ScatAmpPrior[0]=-18;
+        ScatAmpPrior[1]=-4;
 	
 	RedCoeffPrior[0]=-10;
 	RedCoeffPrior[1]=0;
@@ -472,8 +488,9 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 
 
         parameters.readInto(incRED, "incRED", incRED);
-		parameters.readInto(incDM, "incDM", incDM);
-        parameters.readInto(doTimeMargin, "doTimeMargin", doTimeMargin);
+	parameters.readInto(incDM, "incDM", incDM);
+	parameters.readInto(incScat, "incScat", incScat);
+	parameters.readInto(doTimeMargin, "doTimeMargin", doTimeMargin);
         parameters.readInto(doJumpMargin, "doJumpMargin", doJumpMargin);
         parameters.readInto(customPriors, "customPriors", customPriors);
         parameters.readInto(FitSig, "FitSig", FitSig);
@@ -488,9 +505,11 @@ void setupparams(char *ConfigFileName, int &useGPUS,
         parameters.readInto(AmpPrior[0], "AmpPrior[0]", AmpPrior[0]);
         parameters.readInto(AmpPrior[1], "AmpPrior[1]", AmpPrior[1]);
         parameters.readInto(numRedCoeff, "numRedCoeff", numRedCoeff);
-		parameters.readInto(numDMCoeff, "numDMCoeff", numDMCoeff);
+	parameters.readInto(numDMCoeff, "numDMCoeff", numDMCoeff);
+	parameters.readInto(numScatCoeff, "numScatCoeff", numScatCoeff);
         parameters.readInto(numRedPL, "numRedPL", numRedPL);
-		parameters.readInto(numDMPL, "numDMPL", numDMPL);
+	parameters.readInto(numDMPL, "numDMPL", numDMPL);
+	parameters.readInto(numScatPL, "numScatPL", numScatPL);
         parameters.readInto(RedCoeffPrior[0], "RedCoeffPrior[0]", RedCoeffPrior[0]);
         parameters.readInto(RedCoeffPrior[1], "RedCoeffPrior[1]", RedCoeffPrior[1]);
         parameters.readInto(DMCoeffPrior[0], "DMCoeffPrior[0]", DMCoeffPrior[0]);
@@ -499,7 +518,11 @@ void setupparams(char *ConfigFileName, int &useGPUS,
         parameters.readInto(DMAlphaPrior[1], "DMAlphaPrior[1]", DMAlphaPrior[1]);
         parameters.readInto(DMAmpPrior[0], "DMAmpPrior[0]", DMAmpPrior[0]);
         parameters.readInto(DMAmpPrior[1], "DMAmpPrior[1]", DMAmpPrior[1]);
-        
+	parameters.readInto(ScatAlphaPrior[0], "ScatAlphaPrior[0]", ScatAlphaPrior[0]);
+	parameters.readInto(ScatAlphaPrior[1], "ScatAlphaPrior[1]", ScatAlphaPrior[1]);
+	parameters.readInto(ScatAmpPrior[0], "ScatAmpPrior[0]", ScatAmpPrior[0]);
+        parameters.readInto(ScatAmpPrior[1], "ScatAmpPrior[1]", ScatAmpPrior[1]);
+	
         parameters.readInto(FloatingDM, "FloatingDM", FloatingDM);
 	parameters.readInto(yearlyDM, "yearlyDM", yearlyDM);
 	parameters.readInto(incsinusoid, "incsinusoid", incsinusoid);
@@ -526,6 +549,7 @@ void setupparams(char *ConfigFileName, int &useGPUS,
 	parameters.readInto(GWBAmpPrior[1], "GWBAmpPrior[1]", GWBAmpPrior[1]);
 	parameters.readInto(RedPriorType, "RedPriorType", RedPriorType);
 	parameters.readInto(DMPriorType, "DMPriorType", DMPriorType);
+	parameters.readInto(ScatPriorType, "ScatPriorType", ScatPriorType);
 	parameters.readInto(EFACPriorType, "EFACPriorType", EFACPriorType);
 	parameters.readInto(EQUADPriorType, "EQUADPriorType", EQUADPriorType);
 	parameters.readInto(useOriginalErrors, "useOriginalErrors", useOriginalErrors);
@@ -762,7 +786,7 @@ void setTNPriors(char *ConfigFileName, double **Dpriors, long double **TempoPrio
 }
 
 
-void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, int numDMfreqs, int numRedLogFreqs, int numDMLogFreqs, double RedLowFreq, double DMLowFreq, double RedMidFreq, double DMMidFreq){
+void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, int numDMfreqs, int numScatfreqs, int numRedLogFreqs, int numDMLogFreqs, int numScatLogFreqs, double RedLowFreq, double DMLowFreq, double ScatLowFreq, double RedMidFreq, double DMMidFreq, double ScatMidFreq){
 
 //This function sets or overwrites the default values for the sampled frequencies sent to multinest
 
@@ -787,7 +811,12 @@ void setFrequencies(char *ConfigFileName, double *SampleFreq, int numRedfreqs, i
 		startpoint++;
 		//printf("making freqs %i %g", startpoint+i, SampleFreq[startpoint+i]);
         }
-
+	for(int i =0;i < numScatfreqs; i++){
+                SampleFreq[startpoint]=i+1;
+                startpoint++;
+                //printf("making freqs %i %g", startpoint+i, SampleFreq[startpoint+i]);
+        }
+	
 	startpoint=0;
 	for(int i =0;i<numRedfreqs; i++){	
 

--- a/TempoNestPlugin.cpp
+++ b/TempoNestPlugin.cpp
@@ -265,7 +265,7 @@ void SetNewAmps(Archive *archive){
 }
 #endif
 */
-MNStruct* init_struct(pulsar *pulseval,	 long double **LDpriorsval, int numberpulsarsval,int numFitJumpsval,int numFitTimingval, int systemcountval, int numFitEFACval, int numFitEQUADval, int numFitRedCoeffval, int numFitDMCoeffval,int numFitRedPLval, int numFitDMPLval, int **TempoFitNumsval,int *TempoJumpNumsval, int *sysFlagsval, int numdimsval, int incREDval, int incDMval, int incFloatDMval, int incFloatRedval, int DMFloatstartval, int RedFloatstartval, int TimeMarginVal, int JumpMarginVal, int doLinearVal, double *SampleFreqsVal, int incStepVal, char *whiteflagval, int whitemodelval, int varyRedCoeffval, int varyDMCoeffval, int yearlyDMval, int incsinusoidval, int EPolTermsval, int incGWBval,int RedPriorType,int DMPriorType,int EQUADPriorType,int EFACPriorType,int useOriginalErrors, int incShannonJitter, int incDMEvent, int incDMShapeEvent, int numDMShapeCoeff, int incBandNoise, int numFitBandNoiseCoeff, int incRedShapeEvent, int numRedShapeCoeff, int MarginRedShapeCoeff, int incDMScatterShapeEvent, int numDMScatterShapeCoeff, int incNGJitter, int incNGSJitter, int incGlitch, int incGlitchTerms, int incBreakingIndex, int FitLowFreqCutoff, int useNbitsAlgebra, int incGroupNoise, int numFitGroupNoiseCoeff, int **FitForGroup, int numGroupstoFit, int *GroupNoiseFlags, int FitSolarWind, int FitWhiteSolarWind, int interpolateProfile, double InterpolatedTime, int sampler, int *GPTAnumstoccoeff, int totalshapestoccoeff, int StoreFMatrices, int incHighFreqStoc, int numNGJitter, int numNGSJitter, int **FitForBand, int incProfileEvo, double EvoRefFreq, int *numEvoFitCoeff, int incWideBandNoise, int incProfileFit, int *numProfileFitCoeff, int incDMEQUAD, int FitLinearProfileWidth, double offPulseLevel, double **GroupStartTimes, int FitEvoExponent, int numProfComponents, int totalEvoFitCoeff, int totalProfileFitCoeff, int *numEvoCoeff, int totalEvoCoeff, int incWidthJitter, int JitterProfComp, int incProfileEnergyEvo, int debug, int ProfileBaselineTerms, int incProfileNoise, int ProfileNoiseCoeff, int SubIntToFit, int ChannelToFit, int NProfileEvoPoly, double *ProfCompSeps, int usecosiprior, double *PreJumpVals, char *rootName, int doMax, int incWidthEvoTime, int incExtraProfComp, int incPrecession, int incTimeCorrProfileNoise, int *numTimeCorrCoeff, int totalTimeCorrCoeff, double phasePriorExpansion, int ProfileNoiseMethod, int FitPrecAmps, char *GroupNoiseName, int NProfileTimePoly, int incProfileScatter, int ScatterPBF, int *FitCompWidths, int *FitCompPos, int NumFitCompWidths, int NumFitCompPos, int NumCompswithWidth, int NumCompswithPos, int rank)
+MNStruct* init_struct(pulsar *pulseval,	 long double **LDpriorsval, int numberpulsarsval,int numFitJumpsval,int numFitTimingval, int systemcountval, int numFitEFACval, int numFitEQUADval, int numFitRedCoeffval, int numFitDMCoeffval, int numFitScatCoeffval, int numFitRedPLval, int numFitDMPLval, int numFitScatPLval, int **TempoFitNumsval,int *TempoJumpNumsval, int *sysFlagsval, int numdimsval, int incREDval, int incDMval, int incScatval, int incFloatDMval, int incFloatRedval, int DMFloatstartval, int RedFloatstartval, int TimeMarginVal, int JumpMarginVal, int doLinearVal, double *SampleFreqsVal, int incStepVal, char *whiteflagval, int whitemodelval, int varyRedCoeffval, int varyDMCoeffval, int yearlyDMval, int incsinusoidval, int EPolTermsval, int incGWBval,int RedPriorType,int DMPriorType,int ScatPriorType,int EQUADPriorType,int EFACPriorType,int useOriginalErrors, int incShannonJitter, int incDMEvent, int incDMShapeEvent, int numDMShapeCoeff, int incBandNoise, int numFitBandNoiseCoeff, int incRedShapeEvent, int numRedShapeCoeff, int MarginRedShapeCoeff, int incDMScatterShapeEvent, int numDMScatterShapeCoeff, int incNGJitter, int incNGSJitter, int incGlitch, int incGlitchTerms, int incBreakingIndex, int FitLowFreqCutoff, int useNbitsAlgebra, int incGroupNoise, int numFitGroupNoiseCoeff, int **FitForGroup, int numGroupstoFit, int *GroupNoiseFlags, int FitSolarWind, int FitWhiteSolarWind, int interpolateProfile, double InterpolatedTime, int sampler, int *GPTAnumstoccoeff, int totalshapestoccoeff, int StoreFMatrices, int incHighFreqStoc, int numNGJitter, int numNGSJitter, int **FitForBand, int incProfileEvo, double EvoRefFreq, int *numEvoFitCoeff, int incWideBandNoise, int incProfileFit, int *numProfileFitCoeff, int incDMEQUAD, int FitLinearProfileWidth, double offPulseLevel, double **GroupStartTimes, int FitEvoExponent, int numProfComponents, int totalEvoFitCoeff, int totalProfileFitCoeff, int *numEvoCoeff, int totalEvoCoeff, int incWidthJitter, int JitterProfComp, int incProfileEnergyEvo, int debug, int ProfileBaselineTerms, int incProfileNoise, int ProfileNoiseCoeff, int SubIntToFit, int ChannelToFit, int NProfileEvoPoly, double *ProfCompSeps, int usecosiprior, double *PreJumpVals, char *rootName, int doMax, int incWidthEvoTime, int incExtraProfComp, int incPrecession, int incTimeCorrProfileNoise, int *numTimeCorrCoeff, int totalTimeCorrCoeff, double phasePriorExpansion, int ProfileNoiseMethod, int FitPrecAmps, char *GroupNoiseName, int NProfileTimePoly, int incProfileScatter, int ScatterPBF, int *FitCompWidths, int *FitCompPos, int NumFitCompWidths, int NumFitCompPos, int NumCompswithWidth, int NumCompswithPos, int rank)
 {
     MNStruct* MNS = (MNStruct*)malloc(sizeof(MNStruct));
 
@@ -279,14 +279,17 @@ MNStruct* init_struct(pulsar *pulseval,	 long double **LDpriorsval, int numberpu
 	MNS->numFitEQUAD=numFitEQUADval;
 	MNS->numFitRedCoeff=numFitRedCoeffval;
 	MNS->numFitDMCoeff=numFitDMCoeffval;
+	MNS->numFitScatCoeff=numFitScatCoeffval;
 	MNS->numFitRedPL=numFitRedPLval;
 	MNS->numFitDMPL=numFitDMPLval;
+	MNS->numFitScatPL=numFitScatPLval;
 	MNS->TempoFitNums=TempoFitNumsval;
 	MNS->TempoJumpNums=TempoJumpNumsval;
 	MNS->sysFlags=sysFlagsval;
 	MNS->numdims=numdimsval;
 	MNS->incRED=incREDval;
 	MNS->incDM=incDMval;
+	MNS->incScat=incScatval;
 	MNS->incFloatRed=incFloatRedval;
 	MNS->incFloatDM=incFloatDMval;
 	MNS->yearlyDM=yearlyDMval;
@@ -403,7 +406,7 @@ MNStruct* init_struct(pulsar *pulseval,	 long double **LDpriorsval, int numberpu
 	return MNS;
 }
 
-void printPriors(pulsar *psr, long double **TempoPriors, double **Dpriors, int incEFAC, int incEQUAD, int incRED, int incDM, int numRedCoeff, int numDMCoeff, int numFloatRed, int numFloatDM, int fitDMModel, std::string longname, int incStep, int varyRedCoeff, int varyDMCoeff, int yearlyDM, int incsinusoid, int numEPolTerms, int incShannonJitter, void *context){
+void printPriors(pulsar *psr, long double **TempoPriors, double **Dpriors, int incEFAC, int incEQUAD, int incRED, int incDM, int incScat, int numRedCoeff, int numDMCoeff, int numScatCoeff, int numFloatRed, int numFloatDM, int fitDMModel, std::string longname, int incStep, int varyRedCoeff, int varyDMCoeff, int yearlyDM, int incsinusoid, int numEPolTerms, int incShannonJitter, void *context){
 
 
 	std::ofstream getdistparamnames;
@@ -818,6 +821,15 @@ void printPriors(pulsar *psr, long double **TempoPriors, double **Dpriors, int i
                 }
         }
 
+	if(incScat==1){
+	  getdistparamnames <<  "ScatAmp\n";
+	  getdistparamnames <<  "ScatSlope\n";
+	  if (((MNStruct *)context)->rank==0) printf("Prior on Scat Log Amplitude : %.5g -> %.5g\n",Dpriors[paramsfitted][0],Dpriors[paramsfitted][1]);
+	  paramsfitted++;
+	  if (((MNStruct *)context)->rank==0) printf("Prior on Scat Slope : %.5g -> %.5g\n",Dpriors[paramsfitted][0],Dpriors[paramsfitted][1]);
+	  paramsfitted++;
+	}
+	
         if(numFloatDM>0){
         	for(int i =0; i < numFloatDM; i++){
 			getdistparamnames <<  "DMFF"<< i+1 << "\n";
@@ -1309,6 +1321,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	int incRED;
 	int FitLowFreqCutoff=0;
 	int incDM;
+	int incScat;
 
 	int incFloatRed=0;
 	int incFloatDM=0;
@@ -1318,7 +1331,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	int customPriors;
 	int Reddims=0;
 	int DMdims=0;
-	int ScatterDims = 0;
+	int Scatdims = 0;
 	int DMModeldims=0;
 	int fitDMModel=0;
 	double *EFACPrior;
@@ -1328,14 +1341,19 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	double *AmpPrior;
 	double *DMAlphaPrior;
 	double *DMAmpPrior;
+	double *ScatAlphaPrior;
+	double *ScatAmpPrior;
 	double *DMFreqPrior;
 	double *RedFreqPrior;
 	double numRedCoeff;
 	double numDMCoeff;
+	double numScatCoeff;
 	int numRedPL;
 	int numDMPL;
+	int numScatPL;
 	double *RedCoeffPrior;
 	double *DMCoeffPrior;
+	double *ScatCoeffPrior;
 	double FourierSig;
 	double *SampleFreq;
 	int numEFAC=0;
@@ -1359,6 +1377,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	int incsinusoid;
 	int RedPriorType;
 	int DMPriorType;
+	int ScatPriorType;
 	int EQUADPriorType;
 	int EFACPriorType;
 	int useOriginalErrors;
@@ -1378,6 +1397,8 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	AmpPrior=new double[2];
 	DMAlphaPrior=new double[2];
 	DMAmpPrior=new double[2];
+	ScatAlphaPrior=new double[2];
+        ScatAmpPrior=new double[2];
 	RedCoeffPrior=new double[2];
 	DMCoeffPrior=new double[2];
 	RedFreqPrior=new double[2];
@@ -1498,7 +1519,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	int incProfileScatter = 0;
 	int ScatterPBF = 0;
 
-	setupparams(ConfigFileName, useGPUS, Type, numTempo2its, doLinearFit, doMax, incEFAC, numEPolTerms, incEQUAD, incRED, incDM, doTimeMargin, doJumpMargin, FitSig, customPriors, EFACPrior, EPolPrior, EQUADPrior, AlphaPrior, AmpPrior, DMAlphaPrior, DMAmpPrior, numRedCoeff, numDMCoeff, numRedPL, numDMPL, RedCoeffPrior, DMCoeffPrior, incFloatDM, DMFreqPrior, yearlyDM, incsinusoid, incFloatRed, RedFreqPrior, FourierSig, numStep, StepAmpPrior, WhiteName,whitemodel, varyRedCoeff, varyDMCoeff, incGWB, GWBAmpPrior, RedPriorType, DMPriorType, EQUADPriorType, EFACPriorType, useOriginalErrors, incShannonJitter, incDMEvent, DMEventStartPrior, DMEventLengthPrior,incDMShapeEvent, numDMShapeCoeff, DMShapeCoeffPrior, incRedShapeEvent, numRedShapeCoeff, MarginRedShapeCoeff, RedShapeCoeffPrior, incDMScatterShapeEvent, numDMScatterShapeCoeff, DMScatterShapeCoeffPrior,incBandNoise, numBandNoiseCoeff, BandNoiseAmpPrior, BandNoiseAlphaPrior, incNGJitter, incNGSJitter, incGlitch, incGlitchTerms, GlitchFitSig, incBreakingIndex, FitLowFreqCutoff, useNbitsAlgebra, incGroupNoise, numGroupCoeff, GroupNoiseAmpPrior, GroupNoiseAlphaPrior, FitSolarWind, FitWhiteSolarWind, SolarWindPrior, WhiteSolarWindPrior,  GPTA,  GroupNoiseName, FixProfile, FitTemplate, interpolateProfile, InterpolatedTime, StoreFMatrices, incHighFreqStoc, HighFreqStocPrior, incProfileEvo, EvoRefFreq, ProfileEvoPrior, FitEvoExponent, incWideBandNoise, incProfileFit, ProfileFitPrior, FitLinearProfileWidth, LinearProfileWidthPrior, incDMEQUAD, DMEQUADPrior, offPulseLevel,ProfFile,numProfComponents,incWidthJitter,WidthJitterPrior,JitterProfComp,incProfileEnergyEvo,ProfileEnergyEvoPrior, debug, ProfileBaselineTerms, incProfileNoise, ProfileNoiseCoeff, ProfileNoiseAmpPrior, ProfileNoiseSpecPrior, SubIntToFit, ChannelToFit, NProfileEvoPoly, usecosiprior, incWidthEvoTime, incExtraProfComp, removeBaseline, incPrecession, incTimeCorrProfileNoise, phasePriorExpansion, ProfileNoiseMethod, FitPrecAmps, NProfileTimePoly, incProfileScatter, ScatterPBF); 
+	setupparams(ConfigFileName, useGPUS, Type, numTempo2its, doLinearFit, doMax, incEFAC, numEPolTerms, incEQUAD, incRED, incDM, incScat, doTimeMargin, doJumpMargin, FitSig, customPriors, EFACPrior, EPolPrior, EQUADPrior, AlphaPrior, AmpPrior, DMAlphaPrior, DMAmpPrior,ScatAlphaPrior, ScatAmpPrior, numRedCoeff, numDMCoeff, numScatCoeff, numRedPL, numDMPL, numScatPL, RedCoeffPrior, DMCoeffPrior, ScatCoeffPrior, incFloatDM, DMFreqPrior, yearlyDM, incsinusoid, incFloatRed, RedFreqPrior, FourierSig, numStep, StepAmpPrior, WhiteName,whitemodel, varyRedCoeff, varyDMCoeff, incGWB, GWBAmpPrior, RedPriorType, DMPriorType, ScatPriorType, EQUADPriorType, EFACPriorType, useOriginalErrors, incShannonJitter, incDMEvent, DMEventStartPrior, DMEventLengthPrior,incDMShapeEvent, numDMShapeCoeff, DMShapeCoeffPrior, incRedShapeEvent, numRedShapeCoeff, MarginRedShapeCoeff, RedShapeCoeffPrior, incDMScatterShapeEvent, numDMScatterShapeCoeff, DMScatterShapeCoeffPrior,incBandNoise, numBandNoiseCoeff, BandNoiseAmpPrior, BandNoiseAlphaPrior, incNGJitter, incNGSJitter, incGlitch, incGlitchTerms, GlitchFitSig, incBreakingIndex, FitLowFreqCutoff, useNbitsAlgebra, incGroupNoise, numGroupCoeff, GroupNoiseAmpPrior, GroupNoiseAlphaPrior, FitSolarWind, FitWhiteSolarWind, SolarWindPrior, WhiteSolarWindPrior,  GPTA,  GroupNoiseName, FixProfile, FitTemplate, interpolateProfile, InterpolatedTime, StoreFMatrices, incHighFreqStoc, HighFreqStocPrior, incProfileEvo, EvoRefFreq, ProfileEvoPrior, FitEvoExponent, incWideBandNoise, incProfileFit, ProfileFitPrior, FitLinearProfileWidth, LinearProfileWidthPrior, incDMEQUAD, DMEQUADPrior, offPulseLevel,ProfFile,numProfComponents,incWidthJitter,WidthJitterPrior,JitterProfComp,incProfileEnergyEvo,ProfileEnergyEvoPrior, debug, ProfileBaselineTerms, incProfileNoise, ProfileNoiseCoeff, ProfileNoiseAmpPrior, ProfileNoiseSpecPrior, SubIntToFit, ChannelToFit, NProfileEvoPoly, usecosiprior, incWidthEvoTime, incExtraProfComp, removeBaseline, incPrecession, incTimeCorrProfileNoise, phasePriorExpansion, ProfileNoiseMethod, FitPrecAmps, NProfileTimePoly, incProfileScatter, ScatterPBF); 
 
 	if (rank==0) {
 	  printf("PEP %g \n", phasePriorExpansion);
@@ -1534,6 +1555,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 		if(FitForGroup[i][0] ==-1)numGroupstoFit++;
 		if(FitForGroup[i][1] == 1)numGroupTimestoFit++;
 	}
+	if (rank==0) printf("Inc Scat = %d\n", incScat);
 	if (rank==0) printf("Fitting for %i group noise terms, and for %i groups, %i Times \n", incGroupNoise, numGroupstoFit, numGroupTimestoFit);
 	if (rank==0) printf("Fitting for %i band noise terms \n", incBandNoise);
 
@@ -1672,6 +1694,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 
         int Reddaysincoeffs=int(floor(maxtspan/numRedCoeff));
 	int DMdaysincoeffs=int(floor(maxtspan/numDMCoeff));
+	int Scatdaysincoeffs=int(floor(maxtspan/numScatCoeff));
 	int BandDMdaysincoeffs=int(floor(maxtspan/numBandNoiseCoeff));
 	int Groupdaysincoeffs=int(floor(maxtspan/numGroupCoeff));
 
@@ -1691,6 +1714,10 @@ extern "C" int graphicalInterface(int argc, char **argv,
         else{
                 numDMCoeff=int(DMdaysincoeffs);//DMdaysincoeffs;
         }
+	
+	if(numScatCoeff < mindays)  numScatCoeff=mincoeff;
+        else  numScatCoeff=int(Scatdaysincoeffs);//Scatdaysincoeffs;
+
 
         if(numBandNoiseCoeff < mindays){
                 numBandNoiseCoeff=mincoeff;
@@ -1708,9 +1735,10 @@ extern "C" int graphicalInterface(int argc, char **argv,
 
 
 	if(incRED == 0 && incGWB == 0)numRedCoeff=0;
-	if(incDM == 0)numDMCoeff=0;	
-	SampleFreq=new double[int(numRedCoeff+numDMCoeff)];
-	setFrequencies(ConfigFileName, SampleFreq,numRedCoeff, numDMCoeff, 0, 0, 1, 1, 1, 1);
+	if(incDM == 0)numDMCoeff=0;
+	if(incScat == 0)numScatCoeff=0;
+	SampleFreq=new double[int(numRedCoeff+numDMCoeff+numScatCoeff)];
+	setFrequencies(ConfigFileName, SampleFreq,numRedCoeff, numDMCoeff, numScatCoeff, 0, 0, 0, 1, 1, 1, 1, 1, 1);
 	
 
 
@@ -1842,6 +1870,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	if(incDM==5)DMdims=2*numDMCoeff+2;
 	if(incDM==6)DMdims=2*numDMCoeff+numDMCoeff;
 
+	if(incScat==1) Scatdims=2*numScatPL;
 	/*
 	if(incProfileScatter == 1){
 
@@ -2131,6 +2160,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	  if(incDM == 2){printf("Including DM : Model Independant - Fitting %i Coefficients\n", int(numDMCoeff));}
 	  if(incDM ==3){printf("Including DM: %i Component Power Law Model to %i Coefficients \n", numDMPL, int(numDMCoeff));}
 	  if(incDM ==5){printf("Including DM Variations Numerically: Power Law Model to %i Coefficients \n", int(numDMCoeff));}
+	  if(incScat ==1) {printf("Including Scattering variations: %i Component Power Law Model to %i Coefficients \n", numScatPL, int(numScatCoeff));}
 	  if(incFloatDM==1){printf("Including Floating DM power spectrum coefficient\n");}
 	  if(incFloatRed==1){printf("Including Floating Red noise power spectrum coefficient\n");}
 	  if(yearlyDM==1){printf("Including yearly DM variations\n");}
@@ -2315,7 +2345,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 
 
 	double tol = 0.5;				// tol, defines the stopping criteria
-	int ndims = numFitJumps+fitcount+numEFAC*numEPolTerms +numEQUAD+numNGJitter+numNGSJitter+Reddims+DMdims+ numStep*3 + DMModeldims + 2*varyDMCoeff + 2*varyRedCoeff + 2*yearlyDM + 3*incsinusoid+numSQUAD + 7*incDMEvent + Glitchdims +swdims + incHighFreqStoc + incDMEQUAD + incWidthJitter + pnoisedims; // dimensionality (no. of free parameters)
+	int ndims = numFitJumps+fitcount+numEFAC*numEPolTerms +numEQUAD+numNGJitter+numNGSJitter+Reddims+DMdims+Scatdims+numStep*3 + DMModeldims + 2*varyDMCoeff + 2*varyRedCoeff + 2*yearlyDM + 3*incsinusoid+numSQUAD + 7*incDMEvent + Glitchdims +swdims + incHighFreqStoc + incDMEQUAD + incWidthJitter + pnoisedims; // dimensionality (no. of free parameters)
 	int nPar = ndims;					// total no. of parameters including free & derived parameters
 							// note: posterior files are updated & dumper routine is called after every updInt*10 iterations
 	double Ztol = -1E90;				// all the modes with logZ < Ztol are ignored
@@ -2340,7 +2370,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	char *chartroot = new char[longname.length() + 1];
         std::strcpy(chartroot , longname.c_str());
 
-	MNStruct *MNS = init_struct(psr,TempoPriors,npsr,numFitJumps,fitcount,systemcount,numEFAC,numEQUAD, int(numRedCoeff), int(numDMCoeff), numRedPL, numDMPL, TempoFitNums,TempoJumpNums,numFlags, ndims, incRED,incDM, incFloatDM,incFloatRed, FloatDMstart, FloatRedstart, doTimeMargin,doJumpMargin, doLinearFit, SampleFreq, numStep, wflag, whitemodel,varyRedCoeff, varyDMCoeff,yearlyDM, incsinusoid, numEPolTerms, incGWB,RedPriorType, DMPriorType, EQUADPriorType,EFACPriorType,useOriginalErrors,numSQUAD, incDMEvent, incDMShapeEvent, numDMShapeCoeff, incBandNoise, numBandNoiseCoeff, incRedShapeEvent, numRedShapeCoeff, MarginRedShapeCoeff, incDMScatterShapeEvent, numDMScatterShapeCoeff, incNGJitter, incNGSJitter, incGlitch, incGlitchTerms, incBreakingIndex, FitLowFreqCutoff, useNbitsAlgebra, incGroupNoise, numGroupCoeff, FitForGroup, numGroupstoFit,GroupNoiseSys, FitSolarWind, FitWhiteSolarWind, interpolateProfile, InterpolatedTime, sampler, GPTAnumstocshapecoeff, totalshapestoccoeff, StoreFMatrices, incHighFreqStoc, numNGJitter, numNGSJitter, FitForBand, incProfileEvo, EvoRefFreq, numEvoFitCoeff, incWideBandNoise, incProfileFit, numProfileFitCoeff, incDMEQUAD, FitLinearProfileWidth, offPulseLevel,GroupStartTimes, FitEvoExponent,numProfComponents, totalEvoFitCoeff, totalProfileFitCoeff, numEvoCoeff, totalEvoCoeff,incWidthJitter, JitterProfComp, incProfileEnergyEvo, debug, ProfileBaselineTerms, incProfileNoise, ProfileNoiseCoeff, SubIntToFit, ChannelToFit, NProfileEvoPoly, ProfCompSeps,usecosiprior, PreJumpVals, chartroot, doMax, incWidthEvoTime, incExtraProfComp, incPrecession, incTimeCorrProfileNoise, numTimeCorrCoeff, totalTimeCorrCoeff, phasePriorExpansion, ProfileNoiseMethod, FitPrecAmps, GroupNoiseName, NProfileTimePoly, incProfileScatter, ScatterPBF, FitCompWidths, FitCompPos, NumFitCompWidths, NumFitCompPos, NumCompswithWidth, NumCompswithPos, rank);
+	MNStruct *MNS = init_struct(psr,TempoPriors,npsr,numFitJumps,fitcount,systemcount,numEFAC,numEQUAD, int(numRedCoeff), int(numDMCoeff), int(numScatCoeff), numRedPL, numDMPL, numScatPL, TempoFitNums,TempoJumpNums,numFlags, ndims, incRED,incDM,incScat,incFloatDM,incFloatRed, FloatDMstart, FloatRedstart, doTimeMargin,doJumpMargin, doLinearFit, SampleFreq, numStep, wflag, whitemodel,varyRedCoeff, varyDMCoeff,yearlyDM, incsinusoid, numEPolTerms, incGWB,RedPriorType, DMPriorType, ScatPriorType, EQUADPriorType,EFACPriorType,useOriginalErrors,numSQUAD, incDMEvent, incDMShapeEvent, numDMShapeCoeff, incBandNoise, numBandNoiseCoeff, incRedShapeEvent, numRedShapeCoeff, MarginRedShapeCoeff, incDMScatterShapeEvent, numDMScatterShapeCoeff, incNGJitter, incNGSJitter, incGlitch, incGlitchTerms, incBreakingIndex, FitLowFreqCutoff, useNbitsAlgebra, incGroupNoise, numGroupCoeff, FitForGroup, numGroupstoFit,GroupNoiseSys, FitSolarWind, FitWhiteSolarWind, interpolateProfile, InterpolatedTime, sampler, GPTAnumstocshapecoeff, totalshapestoccoeff, StoreFMatrices, incHighFreqStoc, numNGJitter, numNGSJitter, FitForBand, incProfileEvo, EvoRefFreq, numEvoFitCoeff, incWideBandNoise, incProfileFit, numProfileFitCoeff, incDMEQUAD, FitLinearProfileWidth, offPulseLevel,GroupStartTimes, FitEvoExponent,numProfComponents, totalEvoFitCoeff, totalProfileFitCoeff, numEvoCoeff, totalEvoCoeff,incWidthJitter, JitterProfComp, incProfileEnergyEvo, debug, ProfileBaselineTerms, incProfileNoise, ProfileNoiseCoeff, SubIntToFit, ChannelToFit, NProfileEvoPoly, ProfCompSeps,usecosiprior, PreJumpVals, chartroot, doMax, incWidthEvoTime, incExtraProfComp, incPrecession, incTimeCorrProfileNoise, numTimeCorrCoeff, totalTimeCorrCoeff, phasePriorExpansion, ProfileNoiseMethod, FitPrecAmps, GroupNoiseName, NProfileTimePoly, incProfileScatter, ScatterPBF, FitCompWidths, FitCompPos, NumFitCompWidths, NumFitCompPos, NumCompswithWidth, NumCompswithPos, rank);
 	
 	MNS->includeEQsys = includeEQsys;	
 
@@ -2824,6 +2854,17 @@ extern "C" int graphicalInterface(int argc, char **argv,
 	        }
 	}
 
+	if(incScat==1){
+		for(int i =0; i< numScatPL; i++){
+	                Dpriors[pcount][0]=ScatAmpPrior[0];
+			Dpriors[pcount][1]=ScatAmpPrior[1];
+		        pcount++;
+                        Dpriors[pcount][0]=ScatAlphaPrior[0];
+                        Dpriors[pcount][1]=ScatAlphaPrior[1];
+			pcount++;
+		}
+	}
+		
 	if(incFloatDM>0){
 		for(int i =0; i < incFloatDM; i++){
 			Dpriors[pcount][0]=DMFreqPrior[0];
@@ -2973,7 +3014,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 		context=MNS;
 		
 
-		printPriors(psr, TempoPriors, Dpriors, numEFAC, numEQUAD, incRED, incDM, numRedCoeff, numDMCoeff, incFloatRed,incFloatDM, fitDMModel, longname, numStep, varyRedCoeff, varyDMCoeff,yearlyDM, incsinusoid, numEPolTerms,numSQUAD,context);
+		printPriors(psr, TempoPriors, Dpriors, numEFAC, numEQUAD, incRED, incDM, incScat, numRedCoeff, numDMCoeff, numScatCoeff, incFloatRed,incFloatDM, fitDMModel, longname, numStep, varyRedCoeff, varyDMCoeff,yearlyDM, incsinusoid, numEPolTerms,numSQUAD,context);
 
 		if (rank==0) printf("\n\n");
 		ndims=ndims-numToMargin;
@@ -3086,7 +3127,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 
 
 
-		if(do_grades == 1){
+		if(do_grades == 1){ // Deprecated
 
 
 			int FitRedCoeff=2*(((MNStruct *)context)->numFitRedCoeff);
@@ -3208,6 +3249,7 @@ extern "C" int graphicalInterface(int argc, char **argv,
 		   settings.cluster_posteriors = false;
 		   settings.feedback      = 1;
 		   settings.compression_factor = 0.36787944117144233; // ad-hoc number take from PC example, TBC
+		   settings.synchronous = false;
 		   settings.boost_posterior= 5.0;
 
 		if(sample==1){

--- a/TempoNestTextOutput.cpp
+++ b/TempoNestTextOutput.cpp
@@ -533,6 +533,14 @@ void TNtextOutput(pulsar *psr, int npsr, int newpar, long double *Tempo2Fit, voi
 			}
 		}
 
+		if(((MNStruct *)context)->incScat ==1 ){
+			printf("Power Law Scattering Model:\n");
+	                printf("Log Amplitude: %g +/- %g\n",paramarray[fitcount][0], paramarray[fitcount][1]);
+			fitcount++;
+			printf("Spectral Index: %g +/- %g\n",paramarray[fitcount][0], paramarray[fitcount][1]);
+                        fitcount++;
+                }
+
 		if(((MNStruct *)context)->incFloatDM > 0){
 			printf("Floating DM, %i Coefficients used:\n",((MNStruct *)context)->incFloatDM);
 			for(int i =0; i < ((MNStruct *)context)->incFloatDM; i++){
@@ -543,7 +551,6 @@ void TNtextOutput(pulsar *psr, int npsr, int newpar, long double *Tempo2Fit, voi
 				fitcount++;
 		    }
 		}
-
 	}
 
 
@@ -1486,6 +1493,17 @@ void TNtextOutput(pulsar *psr, int npsr, int newpar, long double *Tempo2Fit, voi
                 whitefitcount++;
 
 	}
+	 if(((MNStruct *)context)->incScat ==1 ){
+                fprintf(fout2, "TNScatAmp %g\n", paramarray[whitefitcount][2]);
+                tablefile <<  "Log$_{10}$[Scat Amp] \\dotfill & "<< paramarray[whitefitcount][0] <<" $\\pm$ "<< paramarray[whitefitcount][1] <<"  \\\\ \n";
+		whitefitcount++;
+                 fprintf(fout2, "TNScatGam %g\n", paramarray[whitefitcount][2]);
+                fprintf(fout2, "TNScatC %i\n", ((MNStruct *)context)->numFitDMCoeff);
+
+                tablefile <<  "Scat Index \\dotfill & "<< paramarray[whitefitcount][0] <<" $\\pm$ "<< paramarray[whitefitcount][1] <<"  \\\\ \n";
+		whitefitcount++;
+
+        }
 	if(((MNStruct *)context)->incDMShapeEvent != 0){
                 for(int i =0; i < ((MNStruct *)context)->incDMShapeEvent; i++){
 

--- a/TempoNestTextOutput.cpp
+++ b/TempoNestTextOutput.cpp
@@ -411,7 +411,7 @@ void TNtextOutput(pulsar *psr, int npsr, int newpar, long double *Tempo2Fit, voi
                         }
               //  }
 //        printf("fitcount %i %i\n", fitcount, whitefitcount);	
-	if(incRED != 0 || ((MNStruct *)context)->incDM !=0 ||((MNStruct *)context)->numFitEFAC > 0 || ((MNStruct *)context)->numFitEQUAD > 0){
+	if(incRED != 0 || ((MNStruct *)context)->incDM !=0 || ((MNStruct *)context)->incScat !=0 || ((MNStruct *)context)->numFitEFAC > 0 || ((MNStruct *)context)->numFitEQUAD > 0){
 		whitefitcount=fitcount;
                 printf("------------------------------------------------------------------------------\n");
                 printf("Stochastic Parameters:\n");
@@ -1498,7 +1498,7 @@ void TNtextOutput(pulsar *psr, int npsr, int newpar, long double *Tempo2Fit, voi
                 tablefile <<  "Log$_{10}$[Scat Amp] \\dotfill & "<< paramarray[whitefitcount][0] <<" $\\pm$ "<< paramarray[whitefitcount][1] <<"  \\\\ \n";
 		whitefitcount++;
                  fprintf(fout2, "TNScatGam %g\n", paramarray[whitefitcount][2]);
-                fprintf(fout2, "TNScatC %i\n", ((MNStruct *)context)->numFitDMCoeff);
+                fprintf(fout2, "TNScatC %i\n", ((MNStruct *)context)->numFitScatCoeff);
 
                 tablefile <<  "Scat Index \\dotfill & "<< paramarray[whitefitcount][0] <<" $\\pm$ "<< paramarray[whitefitcount][1] <<"  \\\\ \n";
 		whitefitcount++;

--- a/TempoNestUtilities.cpp
+++ b/TempoNestUtilities.cpp
@@ -2345,6 +2345,7 @@ void getArraySizeInfo(void *context){
 
 	int FitRedCoeff=2*(((MNStruct *)context)->numFitRedCoeff);
 	int FitDMCoeff=2*(((MNStruct *)context)->numFitDMCoeff);
+	int FitScatCoeff=2*(((MNStruct *)context)->numFitScatCoeff);
 	int FitBandNoiseCoeff=2*(((MNStruct *)context)->numFitBandNoiseCoeff);
 	int FitGroupNoiseCoeff = 2*((MNStruct *)context)->numFitGroupNoiseCoeff;
 
@@ -2365,6 +2366,7 @@ void getArraySizeInfo(void *context){
 	int totCoeff=0;
 	if(((MNStruct *)context)->incRED != 0 || ((MNStruct *)context)->incGWB == 1)totCoeff+=FitRedCoeff;
 	if(((MNStruct *)context)->incDM != 0)totCoeff+=FitDMCoeff;
+	if(((MNStruct *)context)->incScat != 0)totCoeff+=FitScatCoeff;
 	if(((MNStruct *)context)->incBandNoise > 0)totCoeff+= ((MNStruct *)context)->incBandNoise*FitBandNoiseCoeff;
 	if(((MNStruct *)context)->incNGJitter >0)totCoeff+=((MNStruct *)context)->numNGJitterEpochs;
 	if(((MNStruct *)context)->incNGSJitter >0)totCoeff+=((MNStruct *)context)->numNGSJitterEpochs;

--- a/TempoNestUtilities.cpp
+++ b/TempoNestUtilities.cpp
@@ -2024,6 +2024,7 @@ void StoreTMatrix(double *TotalMatrix, void *context){
 
 	int FitRedCoeff=2*(((MNStruct *)context)->numFitRedCoeff);
 	int FitDMCoeff=2*(((MNStruct *)context)->numFitDMCoeff);
+	int FitScatCoeff=2*(((MNStruct *)context)->numFitScatCoeff);
 	int FitBandCoeff=2*(((MNStruct *)context)->numFitBandNoiseCoeff);
 	int FitGroupNoiseCoeff = 2*((MNStruct *)context)->numFitGroupNoiseCoeff;
 
@@ -2095,6 +2096,29 @@ void StoreTMatrix(double *TotalMatrix, void *context){
 		startpos += FitDMCoeff;
 	} 
 
+/////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////Scattering variations ////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+	if(((MNStruct *)context)->incScat > 0) {
+	  double *ScatVec=new double[((MNStruct *)context)->pulse->nobs];
+	  for(int o=0;o<((MNStruct *)context)->pulse->nobs; o++)
+	    ScatVec[o]=1./(pow((double)((MNStruct *)context)->pulse->obsn[o].freqSSB/1400e6, 4)); // Referenced to 1.4 Ghz to be consistent with Enterprise; Invert to be consistent with Tempo2 - 20220810 GD/AP
+	  
+	  for(int i=0;i<FitScatCoeff/2;i++){
+	    freqs[startpos+i]=((MNStruct *)context)->sampleFreq[startpos/2 - ((MNStruct *)context)->incFloatRed+i]/maxtspan;
+	    freqs[startpos+i+FitScatCoeff/2]=freqs[startpos+i];
+
+	    for(int k=0;k<((MNStruct *)context)->pulse->nobs;k++){
+	      double time=(double)((MNStruct *)context)->pulse->obsn[k].bat;
+	      TotalMatrix[k + (i+TimetoMargin+startpos)*((MNStruct *)context)->pulse->nobs]=cos(2*M_PI*freqs[startpos+i]*time)*ScatVec[k];
+	      TotalMatrix[k + (i+FitScatCoeff/2+TimetoMargin+startpos)*((MNStruct *)context)->pulse->nobs] = sin(2*M_PI*freqs[startpos+i]*time)*ScatVec[k];
+	      //printf("tot Mat = %lg\n", TotalMatrix[k + (i+TimetoMargin+startpos)*((MNStruct *)context)->pulse->nobs]);
+	    }
+	  }
+	  startpos += FitScatCoeff;
+	  delete[] ScatVec;
+	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////  
 /////////////////////////Band DM/////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. Added a new noise model to deal with Scattering (currently nu = 4). 
2. The model is a power-law - similar to the DM model. 
3. To enable this, set incScat=1 in the config file along with the requisite prior ranges for Amp, Alpha and the number of coefficients. These are ScatAmpPrior, ScatAlphaPrior, numScatCoeff. 
4. If enabled correctly, TempoNest should print out the model parameters before sampling starts. The output par file should also have the relevant model parameters (the max.likelihood values). 